### PR TITLE
fix: mobile nav dropdown menu overflow on resize

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,7 +3,7 @@ import SlickHeading from "../components/SlickHeading"
 
 const Header = () => {
   return (
-    <header className="min-h-screen flex flex-col justify-center items-center z-[100]">
+    <header className="min-h-screen flex flex-col justify-center items-center pt-20 z-[100]">
         <SlickHeading />
     </header>
   )

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -5,7 +5,6 @@ import bg from "../../public/assets/hero-img.png"
 const LandingPage = () => {
   return (
 	  <div className="w-full bg-gray-800">
-		<div className="absolute inset-0 bg-black/60 z-[-50]"></div>
 		<Image 
 			className="z-[-100]"
 			src={bg}
@@ -18,6 +17,7 @@ const LandingPage = () => {
 				objectFit: "cover",
 			}}
 		/>
+		<div className="absolute inset-0 bg-black/60 z-[-50]"></div>
 	</div>
   )
 }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -68,11 +68,11 @@ const Navbar = () => {
                     )}
                 </div>
 
-                <div className={nav ? "xs:hidden fixed top-0 w-full h-screen z-[100]" : ""}>
+                <div className={nav ? "xs:hidden fixed top-0 w-full h-screen z-[100]" : "xs:hidden"}>
                     <div className={
                         nav 
                             ? "fixed top-0 w-full text-center p-10 h-screen ease-in duration-500 bg-[#242424] z-[100]" 
-                            : "fixed top-[-100%] p-10 w-full text-center ease-in duration-300 h-screen bg-[#242424]/80"}>
+                            : "fixed top-[-100%] p-10 w-full text-center ease-in duration-300 h-screen"}>
                     <div>
                         <div className="flex justify-between items-center w-full">
                             {<Logo handleNav={handleNav} />}

--- a/src/components/SlickHeading.jsx
+++ b/src/components/SlickHeading.jsx
@@ -22,7 +22,7 @@ const SlickHeading = () => {
       };
 
       return (
-        <div className="w-full flex flex-col justify-center items-center min-h-screen">
+        <div className="w-full flex flex-col">
           <Slider {...settings} className="max-w-[100%]">
             <div>
               <motion.h1


### PR DESCRIPTION
fix: Prevented mobile nav dropdown menu overflowing on page re-size.