### PR TITLE
fix: Remove padding on main heading to fix bg vh.

### DIFF
--- a/src/components/SlickHeading.jsx
+++ b/src/components/SlickHeading.jsx
@@ -22,7 +22,7 @@ const SlickHeading = () => {
       };
 
       return (
-        <div className="min-h-screen w-full flex flex-col justify-center items-center pt-20">
+        <div className="min-h-screen w-full flex flex-col justify-center items-center">
           <Slider {...settings} className="max-w-[100%]">
             <div>
               <motion.h1


### PR DESCRIPTION
fix: Removed padding on carousel heading to fix issues with main bg not taking up full vh.